### PR TITLE
Retrieve correct fields and line ending from subclasses

### DIFF
--- a/lib/fixy/record.rb
+++ b/lib/fixy/record.rb
@@ -61,12 +61,12 @@ module Fixy
       end
 
       def record_fields
-        @record_fields
+        @record_fields || superclass.try(:record_fields)
       end
 
       def line_ending
         # Use the default line ending unless otherwise specified
-        @line_ending || superclass.line_ending || DEFAULT_LINE_ENDING
+        @line_ending || superclass.try(:line_ending) || DEFAULT_LINE_ENDING
       end
 
       def default_record_fields
@@ -157,7 +157,7 @@ module Fixy
 
     # Retrieves the list of record fields that were set through the class methods.
     def record_fields
-      self.class.record_fields || self.class.superclass.record_fields
+      self.class.record_fields
     end
 
     # Retrieves the line ending for this record type

--- a/lib/fixy/record.rb
+++ b/lib/fixy/record.rb
@@ -66,7 +66,7 @@ module Fixy
 
       def line_ending
         # Use the default line ending unless otherwise specified
-        @line_ending || DEFAULT_LINE_ENDING
+        @line_ending || superclass.line_ending || DEFAULT_LINE_ENDING
       end
 
       def default_record_fields
@@ -157,7 +157,7 @@ module Fixy
 
     # Retrieves the list of record fields that were set through the class methods.
     def record_fields
-      self.class.record_fields
+      self.class.record_fields || self.class.superclass.record_fields
     end
 
     # Retrieves the line ending for this record type


### PR DESCRIPTION
Subclasses that do not create extra fields cannot generate without an error due to not being able to access its superclass' record fields and line ending.